### PR TITLE
fix: add ext-json in requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "license": "GPL-3.0-or-later",
     "require": {
         "php": "^7.2",
+        "ext-json": "*",
         "mcustiel/phiremock-common": "v1.0.0",
         "psr/http-client": "^1.0"
     },


### PR DESCRIPTION
Hi @mcustiel,

Since you use json, `ext-json` should be required.
Otherwise you could use `laminas/laminas-json` that provide a php implementation

Regards