### PR TITLE
Fix php8.4 deprecation warnings

### DIFF
--- a/src/Phiremock.php
+++ b/src/Phiremock.php
@@ -75,7 +75,7 @@ class Phiremock
         ExpectationToArrayConverter $expectationToArrayConverter,
         ArrayToExpectationConverter $arrayToExpectationConverter,
         ScenarioStateInfoToArrayConverter $scenarioStateInfoToArrayConverter,
-        Scheme $scheme = null
+        ?Scheme $scheme = null
     ) {
         $this->host = $host;
         $this->port = $port;

--- a/src/Utils/ConditionsBuilder.php
+++ b/src/Utils/ConditionsBuilder.php
@@ -52,7 +52,7 @@ class ConditionsBuilder
     /** @var FormDataCondition */
     private $formData;
 
-    public function __construct(MethodCondition $methodCondition = null, UrlCondition $urlCondition = null)
+    public function __construct(?MethodCondition $methodCondition = null, ?UrlCondition $urlCondition = null)
     {
         $this->headersConditions = new HeaderConditionCollection();
         $this->formData = new FormDataCondition();

--- a/src/Utils/ConditionsBuilderResult.php
+++ b/src/Utils/ConditionsBuilderResult.php
@@ -30,7 +30,7 @@ class ConditionsBuilderResult
 
     public function __construct(
         RequestConditions $request,
-        ScenarioName $scenarioName = null
+        ?ScenarioName $scenarioName = null
     ) {
         $this->request = $request;
         $this->scenarioName = $scenarioName;

--- a/src/Utils/Http/GuzzlePsr18Client.php
+++ b/src/Utils/Http/GuzzlePsr18Client.php
@@ -30,7 +30,7 @@ class GuzzlePsr18Client implements ClientInterface
     /** @var GuzzleClient */
     private $client;
 
-    public function __construct(GuzzleClient $client = null)
+    public function __construct(?GuzzleClient $client = null)
     {
         $this->client = $client ?? new GuzzleClient(
             [

--- a/src/helper_functions.php
+++ b/src/helper_functions.php
@@ -39,7 +39,7 @@ function request(): ConditionsBuilder
     return new ConditionsBuilder();
 }
 
-function getRequest(string $url = null): ConditionsBuilder
+function getRequest(?string $url = null): ConditionsBuilder
 {
     $builder = A::getRequest();
     if ($url) {
@@ -58,7 +58,7 @@ function putRequest(): ConditionsBuilder
     return A::putRequest();
 }
 
-function deleteRequest(string $url = null): ConditionsBuilder
+function deleteRequest(?string $url = null): ConditionsBuilder
 {
     $builder = A::deleteRequest();
     if ($url) {
@@ -138,12 +138,12 @@ function on(ConditionsBuilder $builder): ExpectationBuilder
     return Phiremock::on($builder);
 }
 
-function onGetRequest(string $url = null): ExpectationBuilder
+function onGetRequest(?string $url = null): ExpectationBuilder
 {
     return Phiremock::on(getRequest($url));
 }
 
-function onDeleteRequest(string $url = null): ExpectationBuilder
+function onDeleteRequest(?string $url = null): ExpectationBuilder
 {
     return Phiremock::on(deleteRequest($url));
 }


### PR DESCRIPTION
 Implicitly marking parameters as nullable is deprecated in PHP8.4, the explicit nullable type must be used instead